### PR TITLE
ci: run on main and tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,14 @@
 # SPDX short identifier: MIT
 
 name: Build
-on: [workflow_dispatch, pull_request]
-
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
 jobs:
   job:
     name: ${{ matrix.os }}-${{ github.workflow }}


### PR DESCRIPTION
this feels like a waste when using PRs for everything, but without running on main, CI on PRs is slow as they don't have any cache entries to load