### PR TITLE
update vcpkg to 2024.02.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(EAT_BUILD)
 
   # Link dependencies
   target_link_libraries(eat PUBLIC adm bw64 ear)
-  target_link_libraries(eat PRIVATE unofficial::ebur128 CLI11::CLI11
+  target_link_libraries(eat PRIVATE unofficial::ebur128
                                     nlohmann_json::nlohmann_json valijson)
 
   # Add eat test target
@@ -166,7 +166,7 @@ if(EAT_BUILD)
 
   if(EAT_BUILD_APPS)
     add_executable(eat-process)
-    target_link_libraries(eat-process PRIVATE EBU::eat)
+    target_link_libraries(eat-process PRIVATE EBU::eat CLI11::CLI11)
 
     add_subdirectory(src/apps)
 


### PR DESCRIPTION
This was motivated by #10 (though may well be unnecessary).

To try this, checkout this branch and:

- remove the build directory
- run `git submodule update --recursive` to update the submodule
- run `./external/vcpkg/bootstrap-vcpkg.sh` to get the right version of vcpkg
- build as normal

the CLI11 port changed from header-only to pre-compiled, and needs a define set to make the headers work properly, so it needs linking to the library which uses it