### PR TITLE
Extra things to ensure compliance with Emission Profile

### DIFF
--- a/data/schemas/CMakeLists.txt
+++ b/data/schemas/CMakeLists.txt
@@ -16,6 +16,8 @@ list(
   rewrite_content_objects_emission.schema.json
   set_profiles.schema.json
   set_programme_loudness.schema.json
+  update_all_programme_loudnesses.schema.json
+  update_all_loudnesses.schema.json
   set_version.schema.json
   validate.schema.json)
 set(config_src_dir "${PROJECT_BINARY_DIR}/src/eat/config_file/schemas")

--- a/data/schemas/parameterless_processes.schema.json
+++ b/data/schemas/parameterless_processes.schema.json
@@ -23,7 +23,9 @@
         {"const": "remove_object_times_common_unsafe"},
         {"const": "remove_importance"},
         {"const": "infer_object_interact"},
-        {"const": "set_content_dialogue_default"}
+        {"const": "set_content_dialogue_default"},
+        {"const": "set_content_language"},
+        {"const": "set_programme_language"}
       ]
     }
   }

--- a/data/schemas/parameterless_processes.schema.json
+++ b/data/schemas/parameterless_processes.schema.json
@@ -16,7 +16,6 @@
         {"const": "fix_stream_pack_refs"},
         {"const": "convert_track_stream_to_channel"},
         {"const": "add_block_rtimes"},
-        {"const": "update_all_programme_loudnesses"},
         {"const": "set_position_defaults"},
         {"const": "remove_silent_atu"},
         {"const": "remove_jump_position"},

--- a/data/schemas/processes.schema.json
+++ b/data/schemas/processes.schema.json
@@ -36,6 +36,12 @@
     },
     {
       "$ref": "parameterless_processes.schema.json"
+    },
+    {
+      "$ref": "update_all_programme_loudnesses.schema.json"
+    },
+    {
+      "$ref": "update_all_loudnesses.schema.json"
     }
   ]
 }

--- a/data/schemas/update_all_loudnesses.schema.json
+++ b/data/schemas/update_all_loudnesses.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "configuration for the update_all_loudnesses process",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "update_all_loudnesses"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "emission": {
+          "description": "True if Emission profile is required",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/data/schemas/update_all_programme_loudnesses.schema.json
+++ b/data/schemas/update_all_programme_loudnesses.schema.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "configuration for the update_all_programme_loudnesses process",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "const": "update_all_programme_loudnesses"
+    },
+    "parameters": {
+      "type": "object",
+      "properties": {
+        "emission": {
+          "description": "True if Emission profile is required",
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/example_configs/conform_to_emission.json
+++ b/example_configs/conform_to_emission.json
@@ -168,7 +168,7 @@
                 "profiles": [
                     {
                         "type": "itu_emission",
-                        "level": 0
+                        "level": 1
                     }
                 ]
             },
@@ -191,8 +191,11 @@
             "out_ports": ["out_axml", "out_samples"]
         },
         {
-            "name": "update_all_programme_loudnesses",
-            "type": "update_all_programme_loudnesses",
+            "name": "update_all_loudnesses",
+            "type": "update_all_loudnesses",
+            "parameters": {
+                "emission": true
+            },
             "in_ports": ["in_axml", "in_samples"],
             "out_ports": ["out_axml"]
         },

--- a/example_configs/conform_to_emission.json
+++ b/example_configs/conform_to_emission.json
@@ -200,6 +200,18 @@
             "out_ports": ["out_axml"]
         },
         {
+            "name": "set_content_language",
+            "type": "set_content_language",
+            "in_ports": ["in_axml"],
+            "out_ports": ["out_axml"]
+        },
+        {
+            "name": "set_programme_language",
+            "type": "set_programme_language",
+            "in_ports": ["in_axml"],
+            "out_ports": ["out_axml"]
+        },
+        {
             "name": "output",
             "type": "write_adm_bw64",
             "in_ports": ["in_axml"]

--- a/include/eat/process/loudness.hpp
+++ b/include/eat/process/loudness.hpp
@@ -7,7 +7,7 @@ namespace eat::process {
 /// a process which measures the loudness of input samples
 /// - in_samples (StreamPort<InterleavedBlockPtr>) : input samples
 /// - out_loudness (DataPort<adm::LoudnessMetadata>) : measured loudness
-framework::ProcessPtr make_measure_loudness(const std::string &name, const ear::Layout &layout);
+framework::ProcessPtr make_measure_loudness(const std::string &name, const ear::Layout &layout, bool emission);
 
 /// a process which sets the loudness of an audioProgramme with the given ID
 /// - in_axml (DataPort<ADMData>) : input ADM data
@@ -20,5 +20,19 @@ framework::ProcessPtr make_set_programme_loudness(const std::string &name, const
 /// - in_axml (DataPort<ADMData>) : input ADM data
 /// - in_samples (StreamPort<InterleavedBlockPtr>) : input samples for in_axml
 /// - out_axml (DataPort<ADMData>) : output ADM data
-framework::ProcessPtr make_update_all_programme_loudnesses(const std::string &name);
+framework::ProcessPtr make_update_all_programme_loudnesses(const std::string &name, bool emission);
+
+/// a process which sets the loudness of an audioContent with the given ID
+/// - in_axml (DataPort<ADMData>) : input ADM data
+/// - in_loudness (DataPort<adm::LoudnessMetadata>) : measured loudness
+/// - out_axml (DataPort<ADMData>) : output ADM data
+framework::ProcessPtr make_set_content_loudness(const std::string &name, const adm::AudioContentId &content_id);
+
+/// a process which measures the loudness of all audioContents and audioProgrammes (by rendering
+/// them to 4+5+0) and updates the axml to match
+/// - in_axml (DataPort<ADMData>) : input ADM data
+/// - in_samples (StreamPort<InterleavedBlockPtr>) : input samples for in_axml
+/// - out_axml (DataPort<ADMData>) : output ADM data
+framework::ProcessPtr make_update_all_loudnesses(const std::string &name, bool emission);
+
 }  // namespace eat::process

--- a/include/eat/process/profile_conversion_misc.hpp
+++ b/include/eat/process/profile_conversion_misc.hpp
@@ -92,4 +92,18 @@ framework::ProcessPtr make_infer_object_interact(const std::string &name);
 /// - out_axml (DataPort<ADMData>) : output ADM data
 framework::ProcessPtr make_set_content_dialogue_default(const std::string &name);
 
+/// set missing audioContent language value to und
+///
+/// ports:
+/// - in_axml (DataPort<ADMData>) : input ADM data
+/// - out_axml (DataPort<ADMData>) : output ADM data
+framework::ProcessPtr make_set_content_language(const std::string &name);
+
+/// set missing audioProgramme language value to und
+///
+/// ports:
+/// - in_axml (DataPort<ADMData>) : input ADM data
+/// - out_axml (DataPort<ADMData>) : output ADM data
+framework::ProcessPtr make_set_programme_language(const std::string &name);
+
 }  // namespace eat::process

--- a/include/eat/process/validate.hpp
+++ b/include/eat/process/validate.hpp
@@ -429,7 +429,7 @@ struct ValidStreamFormatMessage {
   }
 };
 
-/// check that audioStreamFormat contains the invalid combination of both 
+/// check that audioStreamFormat contains the invalid combination of both
 /// audioChannelFormat and audioPackFormat references
 struct ValidStreamFormat {
   static std::string name() { return "ValidStreamFormat"; }
@@ -443,8 +443,9 @@ struct ValidStreamFormat {
 };
 
 /// known checks
-using Check = std::variant<ElementInList<std::string>, ElementInRange<float>, ElementPresent, NumElements,
-                           ObjectContentOrNested, ValidStreamFormat, StringLength, UniqueElements<std::string>, ValidLanguage>;
+using Check =
+    std::variant<ElementInList<std::string>, ElementInRange<float>, ElementPresent, NumElements, ObjectContentOrNested,
+                 ValidStreamFormat, StringLength, UniqueElements<std::string>, ValidLanguage>;
 
 /// messages that known checks can produce
 using Message = detail::ToMessages<Check>;

--- a/include/eat/process/validate.hpp
+++ b/include/eat/process/validate.hpp
@@ -418,9 +418,33 @@ struct ObjectContentOrNested {
   void visit(F) {}
 };
 
+struct ValidStreamFormatMessage {
+  static std::string name() { return "ValidStreamFormatMessage"; }
+
+  adm::AudioStreamFormatId stream_id;
+
+  template <typename F>
+  void visit(F f) {
+    f("stream_id", stream_id);
+  }
+};
+
+/// check that audioStreamFormat contains the invalid combination of both 
+/// audioChannelFormat and audioPackFormat references
+struct ValidStreamFormat {
+  static std::string name() { return "ValidStreamFormat"; }
+
+  using Message = ValidStreamFormatMessage;
+
+  std::vector<Message> run(const ADMData &adm) const;
+
+  template <typename F>
+  void visit(F) {}
+};
+
 /// known checks
 using Check = std::variant<ElementInList<std::string>, ElementInRange<float>, ElementPresent, NumElements,
-                           ObjectContentOrNested, StringLength, UniqueElements<std::string>, ValidLanguage>;
+                           ObjectContentOrNested, ValidStreamFormat, StringLength, UniqueElements<std::string>, ValidLanguage>;
 
 /// messages that known checks can produce
 using Message = detail::ToMessages<Check>;
@@ -463,6 +487,7 @@ void format_results(std::ostream &s, const ValidationResults &results, bool show
 
 /// build a validator for a given emission profile level
 ProfileValidator make_emission_profile_validator(int level);
+
 /// build a validator for a known profile
 ProfileValidator make_profile_validator(const profiles::Profile &);
 

--- a/src/eat/config_file/make_process.cpp
+++ b/src/eat/config_file/make_process.cpp
@@ -305,6 +305,8 @@ framework::ProcessPtr make_process(nlohmann::json &config) {
       {"set_version", &make_set_version},
       {"set_content_dialogue_default", make_process_no_args(&process::make_set_content_dialogue_default)},
       {"limit_interaction", &make_limit_interaction},
+      {"set_content_language", make_process_no_args(&process::make_set_content_language)},
+      {"set_programme_language", make_process_no_args(&process::make_set_programme_language)},
   }};
 
   std::string type = get<std::string>(config, "type");

--- a/src/eat/config_file/make_process.cpp
+++ b/src/eat/config_file/make_process.cpp
@@ -177,8 +177,9 @@ framework::ProcessPtr make_render(nlohmann::json &config, const std::string &nam
 framework::ProcessPtr make_measure_loudness(nlohmann::json &config, const std::string &name) {
   auto layout_name = get<std::string>(config, "layout");
   auto layout = ear::getLayout(layout_name);
+  bool emission = get<bool>(config, "emission");
 
-  return process::make_measure_loudness(name, layout);
+  return process::make_measure_loudness(name, layout, emission);
 }
 
 framework::ProcessPtr make_set_programme_loudness(nlohmann::json &config, const std::string &name) {
@@ -186,6 +187,18 @@ framework::ProcessPtr make_set_programme_loudness(nlohmann::json &config, const 
   auto id = adm::parseAudioProgrammeId(id_str);
 
   return process::make_set_programme_loudness(name, id);
+}
+
+framework::ProcessPtr make_update_all_programme_loudnesses(nlohmann::json &config, const std::string &name) {
+  bool emission = get<bool>(config, "emission");
+
+  return process::make_update_all_programme_loudnesses(name, emission);
+}
+
+framework::ProcessPtr make_update_all_loudnesses(nlohmann::json &config, const std::string &name) {
+  bool emission = get<bool>(config, "emission");
+
+  return process::make_update_all_loudnesses(name, emission);
 }
 
 framework::ProcessPtr make_set_profiles(nlohmann::json &config, const std::string &name) {
@@ -276,7 +289,8 @@ framework::ProcessPtr make_process(nlohmann::json &config) {
       {"render", &make_render},
       {"measure_loudness", &make_measure_loudness},
       {"set_programme_loudness", &make_set_programme_loudness},
-      {"update_all_programme_loudnesses", make_process_no_args(&process::make_update_all_programme_loudnesses)},
+      {"update_all_programme_loudnesses", &make_update_all_programme_loudnesses},
+      {"update_all_loudnesses", &make_update_all_loudnesses},
       {"set_profiles", &make_set_profiles},
       {"set_position_defaults", make_process_no_args(&process::make_set_position_defaults)},
       {"remove_silent_atu", make_process_no_args(&process::make_remove_silent_atu)},

--- a/src/eat/process/adm_bw64.cpp
+++ b/src/eat/process/adm_bw64.cpp
@@ -27,7 +27,7 @@ class ADMReader : public FunctionalAtomicProcess {
 
     ADMData adm;
 
-    auto doc = adm::parseXml(axml);
+    auto doc = adm::parseXml(axml, adm::xml::ParserOptions::recursive_node_search);
     load_chna(*doc, adm.channel_map, *file->chnaChunk());
     adm.document = std::move(doc);
 

--- a/src/eat/process/adm_bw64.cpp
+++ b/src/eat/process/adm_bw64.cpp
@@ -28,7 +28,11 @@ class ADMReader : public FunctionalAtomicProcess {
     ADMData adm;
 
     auto doc = adm::parseXml(axml, adm::xml::ParserOptions::recursive_node_search);
-    load_chna(*doc, adm.channel_map, *file->chnaChunk());
+    if (file->chnaChunk() != nullptr) {
+      load_chna(*doc, adm.channel_map, *file->chnaChunk());
+    } else {
+      throw std::runtime_error(path + " does not contain a chna chunk");
+    }
     adm.document = std::move(doc);
 
     out_axml->set_value(std::move(adm));

--- a/src/eat/process/loudness.cpp
+++ b/src/eat/process/loudness.cpp
@@ -51,8 +51,9 @@ NamedType named_cast(Value v) {
 
 class MeasureLoudness : public StreamingAtomicProcess {
  public:
-  MeasureLoudness(const std::string &name, const ear::Layout &layout)
+  MeasureLoudness(const std::string &name, const ear::Layout &layout, bool emission)
       : StreamingAtomicProcess(name),
+        emission_(emission),
         in_samples(add_in_port<StreamPort<InterleavedBlockPtr>>("in_samples")),
         out_loudness(add_out_port<DataPort<adm::LoudnessMetadata>>("out_loudness")),
         fs(48000),
@@ -98,16 +99,19 @@ class MeasureLoudness : public StreamingAtomicProcess {
 
     adm::LoudnessMetadata loudness;
     loudness.set(named_cast<adm::IntegratedLoudness>(integrated));
-    loudness.set(named_cast<adm::LoudnessRange>(range));
-    loudness.set(named_cast<adm::MaxTruePeak>(true_peak));
+    if (!emission_) {
+      loudness.set(named_cast<adm::LoudnessRange>(range));
+      loudness.set(named_cast<adm::MaxTruePeak>(true_peak));
 
-    loudness.set(adm::LoudnessMethod{"ITU-R BS.1770"});
-    loudness.set(adm::LoudnessRecType{"EBU R128"});
+      loudness.set(adm::LoudnessMethod{"ITU-R BS.1770"});
+      loudness.set(adm::LoudnessRecType{"EBU R128"});
+    }
 
     out_loudness->set_value(std::move(loudness));
   }
 
  private:
+  bool emission_;
   StreamPortPtr<InterleavedBlockPtr> in_samples;
   DataPortPtr<adm::LoudnessMetadata> out_loudness;
   unsigned int fs;
@@ -115,8 +119,8 @@ class MeasureLoudness : public StreamingAtomicProcess {
   std::unique_ptr<ebur128_state, ebur128_state_deleter> state;
 };
 
-framework::ProcessPtr make_measure_loudness(const std::string &name, const ear::Layout &layout) {
-  return std::make_shared<MeasureLoudness>(name, layout);
+framework::ProcessPtr make_measure_loudness(const std::string &name, const ear::Layout &layout, bool emission) {
+  return std::make_shared<MeasureLoudness>(name, layout, emission);
 }
 
 class SetProgrammeLoudness : public FunctionalAtomicProcess {
@@ -157,8 +161,9 @@ framework::ProcessPtr make_set_programme_loudness(const std::string &name, const
 
 class UpdateAllProgrammeLoudnesses : public DynamicSubgraph {
  public:
-  UpdateAllProgrammeLoudnesses(const std::string &name)
+  UpdateAllProgrammeLoudnesses(const std::string &name, bool emission)
       : DynamicSubgraph(name),
+        emission_(emission),
         in_samples(add_in_port<StreamPort<InterleavedBlockPtr>>("in_samples")),
         in_axml(add_in_port<DataPort<ADMData>>("in_axml")),
         out_axml(add_out_port<DataPort<ADMData>>("out_axml")) {}
@@ -186,7 +191,7 @@ class UpdateAllProgrammeLoudnesses : public DynamicSubgraph {
       render::SelectionOptionsId options = {render::ProgrammeIdStart{id}};
       auto render = render::make_render("measure_" + id_str, layout, 1024, options);
       graph->register_process(render);
-      auto measure = graph->add_process<MeasureLoudness>("measure_" + id_str, layout);
+      auto measure = graph->add_process<MeasureLoudness>("measure_" + id_str, layout, emission_);
       auto update = graph->add_process<SetProgrammeLoudness>("update_" + id_str, id);
 
       graph->connect(parent_in_samples->port, render->get_in_port("in_samples"));
@@ -203,13 +208,129 @@ class UpdateAllProgrammeLoudnesses : public DynamicSubgraph {
   }
 
  private:
+  bool emission_;
   StreamPortPtr<InterleavedBlockPtr> in_samples;
   DataPortPtr<ADMData> in_axml;
   DataPortPtr<ADMData> out_axml;
 };
 
-framework::ProcessPtr make_update_all_programme_loudnesses(const std::string &name) {
-  return std::make_shared<UpdateAllProgrammeLoudnesses>(name);
+framework::ProcessPtr make_update_all_programme_loudnesses(const std::string &name, bool emission) {
+  return std::make_shared<UpdateAllProgrammeLoudnesses>(name, emission);
+}
+
+
+class SetContentLoudness : public FunctionalAtomicProcess {
+ public:
+  SetContentLoudness(const std::string &name, const adm::AudioContentId &content_id_)
+      : FunctionalAtomicProcess(name),
+        in_axml(add_in_port<DataPort<ADMData>>("in_axml")),
+        in_loudness(add_in_port<DataPort<adm::LoudnessMetadata>>("in_loudness")),
+        out_axml(add_out_port<DataPort<ADMData>>("out_axml")),
+        content_id(content_id_) {}
+
+  void process() override {
+    auto adm = std::move(in_axml->get_value());
+    auto doc = adm.document.move_or_copy();
+
+    auto loudness = std::move(in_loudness->get_value());
+
+    auto content = doc->lookup(content_id);
+    if (!content) throw std::runtime_error("could not find content " + adm::formatId(content_id));
+
+    content->unset<adm::LoudnessMetadatas>();
+    content->add(loudness);
+
+    adm.document = std::move(doc);
+    out_axml->set_value(std::move(adm));
+  }
+
+ private:
+  DataPortPtr<ADMData> in_axml;
+  DataPortPtr<adm::LoudnessMetadata> in_loudness;
+  DataPortPtr<ADMData> out_axml;
+  adm::AudioContentId content_id;
+};
+
+framework::ProcessPtr make_set_content_loudness(const std::string &name, const adm::AudioContentId &content_id) {
+  return std::make_shared<SetContentLoudness>(name, content_id);
+}
+
+
+class UpdateAllLoudnesses : public DynamicSubgraph {
+ public:
+  UpdateAllLoudnesses(const std::string &name, bool emission)
+      : DynamicSubgraph(name),
+        emission_(emission),
+        in_samples(add_in_port<StreamPort<InterleavedBlockPtr>>("in_samples")),
+        in_axml(add_in_port<DataPort<ADMData>>("in_axml")),
+        out_axml(add_out_port<DataPort<ADMData>>("out_axml")) {}
+
+ protected:
+  virtual GraphPtr build_subgraph() override {
+    auto graph = std::make_shared<Graph>();
+
+    auto parent_in_axml = graph->add_process<ParentDataInput<ADMData>>(std::string{"in_axml"});
+    auto parent_out_axml = graph->add_process<ParentDataOutput<ADMData>>(std::string{"out_axml"});
+    auto parent_in_samples = graph->add_process<ParentStreamInput<InterleavedBlockPtr>>(std::string{"in_samples"});
+
+    // axml is passed through one SetProgrammeLoudness per programme before the
+    // output; this will be updated on each loop to point to the output port of
+    // the last SetProgrammeLoudness
+    PortPtr current_axml_port = parent_in_axml->get_out_port("out");
+
+    auto layout = ear::getLayout("4+5+0");
+
+    auto adm = in_axml->get_value().document.read();
+    for (const auto &programme : adm->getElements<adm::AudioProgramme>()) {
+      auto id = programme->get<adm::AudioProgrammeId>();
+      std::string id_str = adm::formatId(id);
+
+      render::SelectionOptionsId options = {render::ProgrammeIdStart{id}};
+      auto render = render::make_render("measure_" + id_str, layout, 1024, options);
+      graph->register_process(render);
+      auto measure = graph->add_process<MeasureLoudness>("measure_" + id_str, layout, emission_);
+      auto update = graph->add_process<SetProgrammeLoudness>("update_" + id_str, id);
+
+      graph->connect(parent_in_samples->port, render->get_in_port("in_samples"));
+      graph->connect(parent_in_axml->port, render->get_in_port("in_axml"));
+      graph->connect(render->get_out_port("out_samples"), measure->get_in_port("in_samples"));
+      graph->connect(measure->get_out_port("out_loudness"), update->get_in_port("in_loudness"));
+      graph->connect(current_axml_port, update->get_in_port("in_axml"));
+      current_axml_port = update->get_out_port("out_axml");
+    }
+
+    for (const auto &content : adm->getElements<adm::AudioContent>()) {
+      auto id = content->get<adm::AudioContentId>();
+      std::string id_str = adm::formatId(id);
+
+      render::SelectionOptionsId options = {render::ContentIdStart{id}};
+      auto render = render::make_render("measure_" + id_str, layout, 1024, options);
+      graph->register_process(render);
+      auto measure = graph->add_process<MeasureLoudness>("measure_" + id_str, layout, emission_);
+      auto update = graph->add_process<SetContentLoudness>("update_" + id_str, id);
+
+      graph->connect(parent_in_samples->port, render->get_in_port("in_samples"));
+      graph->connect(parent_in_axml->port, render->get_in_port("in_axml"));
+      graph->connect(render->get_out_port("out_samples"), measure->get_in_port("in_samples"));
+      graph->connect(measure->get_out_port("out_loudness"), update->get_in_port("in_loudness"));
+      graph->connect(current_axml_port, update->get_in_port("in_axml"));
+      current_axml_port = update->get_out_port("out_axml");
+    }
+
+    graph->connect(current_axml_port, parent_out_axml->port);
+
+    return graph;
+  }
+
+ private:
+  bool emission_;
+  StreamPortPtr<InterleavedBlockPtr> in_samples;
+  DataPortPtr<ADMData> in_axml;
+  DataPortPtr<ADMData> out_axml;
+};
+
+framework::ProcessPtr make_update_all_loudnesses(const std::string &name, bool emission) {
+  return std::make_shared<UpdateAllLoudnesses>(name, emission);
 }
 
 }  // namespace eat::process

--- a/src/eat/process/loudness.cpp
+++ b/src/eat/process/loudness.cpp
@@ -218,7 +218,6 @@ framework::ProcessPtr make_update_all_programme_loudnesses(const std::string &na
   return std::make_shared<UpdateAllProgrammeLoudnesses>(name, emission);
 }
 
-
 class SetContentLoudness : public FunctionalAtomicProcess {
  public:
   SetContentLoudness(const std::string &name, const adm::AudioContentId &content_id_)
@@ -254,7 +253,6 @@ class SetContentLoudness : public FunctionalAtomicProcess {
 framework::ProcessPtr make_set_content_loudness(const std::string &name, const adm::AudioContentId &content_id) {
   return std::make_shared<SetContentLoudness>(name, content_id);
 }
-
 
 class UpdateAllLoudnesses : public DynamicSubgraph {
  public:

--- a/src/eat/process/profile_conversion_misc.cpp
+++ b/src/eat/process/profile_conversion_misc.cpp
@@ -17,8 +17,8 @@ namespace eat::process {
 
 struct ToAdmProfile {
   adm::Profile operator()(profiles::ITUEmissionProfile &p) {
-    return adm::Profile{adm::ProfileValue{"ITU-R BS.[ADM-NGA-Emission]-0"},
-                        adm::ProfileName{"AdvSS Emission ADM and S-ADM Profile"}, adm::ProfileVersion{"1"},
+    return adm::Profile{adm::ProfileValue{"ITU-R BS.2168"},
+                        adm::ProfileName{"Advanced sound system: ADM and S-ADM profile for emission"}, adm::ProfileVersion{"1"},
                         adm::ProfileLevel{std::to_string(p.level())}};
   }
 };
@@ -38,6 +38,10 @@ class SetProfiles : public FunctionalAtomicProcess {
     std::vector<adm::Profile> adm_profiles;
     for (auto &profile : profiles) adm_profiles.push_back(std::visit(ToAdmProfile(), profile));
 
+    auto profile_list = std::make_shared<adm::ProfileList>();
+    for (auto &adm_profile : adm_profiles) {
+      profile_list->add(adm_profile);
+    }
     doc->set(adm::ProfileList{std::move(adm_profiles)});
 
     adm.document = std::move(doc);

--- a/src/eat/process/profile_conversion_misc.cpp
+++ b/src/eat/process/profile_conversion_misc.cpp
@@ -867,4 +867,60 @@ ProcessPtr make_set_content_dialogue_default(const std::string &name) {
   return std::make_shared<SetContentDialogueDefault>(name);
 }
 
+class SetContentLanguage : public FunctionalAtomicProcess {
+ public:
+  SetContentLanguage(const std::string &name)
+      : FunctionalAtomicProcess(name),
+        in_axml(add_in_port<DataPort<ADMData>>("in_axml")),
+        out_axml(add_out_port<DataPort<ADMData>>("out_axml")) {}
+
+  void process() override {
+    auto adm = std::move(in_axml->get_value());
+    auto doc = adm.document.move_or_copy();
+
+    for (auto &content : doc->getElements<adm::AudioContent>()) {
+      if (!content->has<adm::AudioContentLanguage>()) content->set(adm::AudioContentLanguage("und"));
+    }
+
+    adm.document = std::move(doc);
+    out_axml->set_value(std::move(adm));
+  }
+
+ private:
+  DataPortPtr<ADMData> in_axml;
+  DataPortPtr<ADMData> out_axml;
+};
+
+ProcessPtr make_set_content_language(const std::string &name) {
+  return std::make_shared<SetContentLanguage>(name);
+}
+
+class SetProgrammeLanguage : public FunctionalAtomicProcess {
+ public:
+  SetProgrammeLanguage(const std::string &name)
+      : FunctionalAtomicProcess(name),
+        in_axml(add_in_port<DataPort<ADMData>>("in_axml")),
+        out_axml(add_out_port<DataPort<ADMData>>("out_axml")) {}
+
+  void process() override {
+    auto adm = std::move(in_axml->get_value());
+    auto doc = adm.document.move_or_copy();
+
+    for (auto &programme : doc->getElements<adm::AudioProgramme>()) {
+      if (!programme->has<adm::AudioProgrammeLanguage>()) programme->set(adm::AudioProgrammeLanguage("und"));
+    }
+
+    adm.document = std::move(doc);
+    out_axml->set_value(std::move(adm));
+  }
+
+ private:
+  DataPortPtr<ADMData> in_axml;
+  DataPortPtr<ADMData> out_axml;
+};
+
+ProcessPtr make_set_programme_language(const std::string &name) {
+  return std::make_shared<SetProgrammeLanguage>(name);
+}
+
 }  // namespace eat::process

--- a/src/eat/process/profile_conversion_misc.cpp
+++ b/src/eat/process/profile_conversion_misc.cpp
@@ -18,8 +18,8 @@ namespace eat::process {
 struct ToAdmProfile {
   adm::Profile operator()(profiles::ITUEmissionProfile &p) {
     return adm::Profile{adm::ProfileValue{"ITU-R BS.2168"},
-                        adm::ProfileName{"Advanced sound system: ADM and S-ADM profile for emission"}, adm::ProfileVersion{"1"},
-                        adm::ProfileLevel{std::to_string(p.level())}};
+                        adm::ProfileName{"Advanced sound system: ADM and S-ADM profile for emission"},
+                        adm::ProfileVersion{"1"}, adm::ProfileLevel{std::to_string(p.level())}};
   }
 };
 
@@ -891,9 +891,7 @@ class SetContentLanguage : public FunctionalAtomicProcess {
   DataPortPtr<ADMData> out_axml;
 };
 
-ProcessPtr make_set_content_language(const std::string &name) {
-  return std::make_shared<SetContentLanguage>(name);
-}
+ProcessPtr make_set_content_language(const std::string &name) { return std::make_shared<SetContentLanguage>(name); }
 
 class SetProgrammeLanguage : public FunctionalAtomicProcess {
  public:
@@ -919,8 +917,6 @@ class SetProgrammeLanguage : public FunctionalAtomicProcess {
   DataPortPtr<ADMData> out_axml;
 };
 
-ProcessPtr make_set_programme_language(const std::string &name) {
-  return std::make_shared<SetProgrammeLanguage>(name);
-}
+ProcessPtr make_set_programme_language(const std::string &name) { return std::make_shared<SetProgrammeLanguage>(name); }
 
 }  // namespace eat::process

--- a/src/eat/process/validate.cpp
+++ b/src/eat/process/validate.cpp
@@ -169,7 +169,7 @@ struct FormatVisitor {
   std::string operator()(const ValidStreamFormatMessage &m) {
     return adm::formatId(m.stream_id) + " has both audioPackForamtIdRef and audioTrackFormatIdRef elements";
   }
-  
+
   std::string operator()(const StringLength &c) {
     return ev::dotted_path(c.path) + " must be " + c.range.format() + " characters long";
   }
@@ -322,6 +322,9 @@ ProfileValidator make_emission_profile_validator(int level) {
       ValidLanguage{{"audioProgramme", "language"}, LanguageCodeType::REGULAR | LanguageCodeType::UNDETERMINED});
   checks.push_back(
       ValidLanguage{{"audioContent", "language"}, LanguageCodeType::REGULAR | LanguageCodeType::UNDETERMINED});
+
+  checks.push_back(ElementPresent{{"audioProgramme"}, "language", true});
+  checks.push_back(ElementPresent{{"audioContent"}, "language", true});
 
   checks.push_back(ElementPresent{{"audioProgramme", "label"}, "language", true});
   checks.push_back(ElementPresent{{"audioContent", "label"}, "language", true});

--- a/src/eat/process/validate.cpp
+++ b/src/eat/process/validate.cpp
@@ -71,6 +71,27 @@ std::vector<ObjectContentOrNested::Message> ObjectContentOrNested::run(const ADM
   return messages;
 }
 
+std::vector<ValidStreamFormat::Message> ValidStreamFormat::run(const ADMData &adm) const {
+  std::vector<Message> messages;
+  auto elements = adm.document.read()->getElements<adm::AudioStreamFormat>();
+
+  for (auto &&element : elements) {
+    // Having both these referenced is invalid
+    auto apf = element->getReference<adm::AudioPackFormat>();
+    auto acf = element->getReference<adm::AudioChannelFormat>();
+    bool invalid = false;
+    if (apf && acf) {
+      invalid = true;
+    }
+
+    if (invalid) {
+      messages.push_back({element->get<adm::AudioStreamFormatId>()});
+    }
+  }
+
+  return messages;
+}
+
 ValidationResults ProfileValidator::run(const ADMData &adm) const {
   ValidationResults results;
 
@@ -141,6 +162,14 @@ struct FormatVisitor {
     return adm::formatId(m.object_id) + " has " + (m.both ? "both" : "neither");
   }
 
+  std::string operator()(const ValidStreamFormat &) {
+    return "audioStreamFormat must NOT have both audioPackForamtIdRef and audioTrackFormatIdRef elements";
+  }
+
+  std::string operator()(const ValidStreamFormatMessage &m) {
+    return adm::formatId(m.stream_id) + " has both audioPackForamtIdRef and audioTrackFormatIdRef elements";
+  }
+  
   std::string operator()(const StringLength &c) {
     return ev::dotted_path(c.path) + " must be " + c.range.format() + " characters long";
   }

--- a/src/examples/eat_measure_loudness.cpp
+++ b/src/examples/eat_measure_loudness.cpp
@@ -27,7 +27,7 @@ int main(int argc, char **argv) {
   // equivalent to example_configs/measure_all_loudness.json
   auto reader = g.register_process(make_read_adm_bw64("reader", in_path, 1024));
   auto add_block_rtimes = g.register_process(make_add_block_rtimes("add_block_rtimes"));
-  auto measure_loudness = g.register_process(make_update_all_programme_loudnesses("measure_loudness"));
+  auto measure_loudness = g.register_process(make_update_all_programme_loudnesses("measure_loudness", false));
   auto writer = g.register_process(make_write_adm_bw64("writer", out_path));
 
   g.connect(reader->get_out_port("out_samples"), writer->get_in_port("in_samples"));


### PR DESCRIPTION
Added 'emission' flag parameter to the loudness measurement processes, so they only generates the appropriate parameters for the Emission Profile.
Added default language attribute (to "und") for audioProgramme and audioContent which are required for the Emission Profile.
